### PR TITLE
Change tide repo url to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tide"]
 	path = tide
-	url = git@github.com:tide-framework/tide.git
+	url = https://github.com/tide-framework/tide.git


### PR DESCRIPTION
I suggest changing tide submodule url to https protocol, as ssh enforces users to be registered at github and have ssh keys set up
